### PR TITLE
fix: return instances from service in a predictable order

### DIFF
--- a/internal/core/domain/public_cloud/instances.go
+++ b/internal/core/domain/public_cloud/instances.go
@@ -1,3 +1,15 @@
 package public_cloud
 
+import (
+	"sort"
+)
+
 type Instances []Instance
+
+func (inst Instances) OrderById() Instances {
+	sort.Slice(inst, func(i, j int) bool {
+		return inst[i].Id < inst[j].Id
+	})
+
+	return inst
+}

--- a/internal/core/domain/public_cloud/instances_test.go
+++ b/internal/core/domain/public_cloud/instances_test.go
@@ -1,0 +1,16 @@
+package public_cloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInstances_OrderById(t *testing.T) {
+	instances := Instances{Instance{Id: "d"}, Instance{Id: "2"}, Instance{Id: "c"}}
+
+	got := instances.OrderById()
+	want := Instances{Instance{Id: "2"}, Instance{Id: "c"}, Instance{Id: "d"}}
+
+	assert.Equal(t, want, got)
+}

--- a/internal/core/services/public_cloud/service.go
+++ b/internal/core/services/public_cloud/service.go
@@ -85,7 +85,7 @@ func (srv *Service) CreateInstance(
 		return nil, errors.NewFromRepositoryError("CreateInstance", *err)
 	}
 
-	// call GetInstance as createdInstance is created from instanceDetails and not instanceDetails
+	// call GetInstance as createdInstance is created from instance and not instanceDetails
 	return srv.GetInstance(createdInstance.Id, ctx)
 }
 
@@ -246,7 +246,7 @@ func (srv *Service) getImage(
 	return image, nil
 }
 
-// Populate instanceDetails with missing details.
+// Populate instance with missing details.
 func (srv *Service) populateMissingInstanceAttributes(
 	instance public_cloud.Instance,
 	ctx context.Context,

--- a/internal/core/services/public_cloud/service.go
+++ b/internal/core/services/public_cloud/service.go
@@ -56,6 +56,8 @@ func (srv *Service) GetAllInstances(ctx context.Context) (
 		}
 	}
 
+	// Order the results as the channel result order is unpredictable.
+	detailedInstances.OrderById()
 	return detailedInstances, nil
 }
 
@@ -83,7 +85,7 @@ func (srv *Service) CreateInstance(
 		return nil, errors.NewFromRepositoryError("CreateInstance", *err)
 	}
 
-	// call GetInstance as createdInstance is created from instance and not instanceDetails
+	// call GetInstance as createdInstance is created from instanceDetails and not instanceDetails
 	return srv.GetInstance(createdInstance.Id, ctx)
 }
 
@@ -230,7 +232,7 @@ func (srv *Service) getImage(
 	}
 
 	for _, image := range images {
-		srv.cachedImages.Set(id, image)
+		srv.cachedImages.Set(image.Id, image)
 	}
 
 	image, imageErr := images.FilterById(id)
@@ -244,7 +246,7 @@ func (srv *Service) getImage(
 	return image, nil
 }
 
-// Populate instance with missing details.
+// Populate instanceDetails with missing details.
 func (srv *Service) populateMissingInstanceAttributes(
 	instance public_cloud.Instance,
 	ctx context.Context,


### PR DESCRIPTION
Make sure services are returned from the services in a predictable order