### PR TITLE
fix: set directories where Dockerfiles are found

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,9 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "/docker/golang"
+      - "/docker/node"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Previous config was incorrect as dependabot does not support recursive search for Dockerfiles