### PR TITLE
fix: set the proper hostnames in the prism-proxy Caddyfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - ./:/app
     working_dir: /app
   prism_public_cloud:
+    container_name: prism_public_cloud
     build:
       dockerfile: docker/prism/Dockerfile
     command: >
@@ -43,6 +44,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
   prism_dedicated_server:
+    container_name: prism_dedicated_server
     build:
       dockerfile: docker/prism/Dockerfile
     command: >
@@ -56,7 +58,7 @@ services:
     build:
       dockerfile: docker/caddy/Dockerfile
     volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./docker/caddy/prism/Caddyfile:/etc/caddy/Caddyfile
     ports:
       - "8080:80"
     depends_on:

--- a/docker/caddy/prism/Caddyfile
+++ b/docker/caddy/prism/Caddyfile
@@ -2,10 +2,10 @@ http://localhost
 
 route /publicCloud/v1/* {
 	uri strip_prefix /publicCloud/v1
-	reverse_proxy prism_publicCloud:4010
+	reverse_proxy prism_public_cloud:4010
 }
 
 route /bareMetals/v2/* {
 	uri strip_prefix /bareMetals/v2
-	reverse_proxy prism_dedicatedServer:4010
+	reverse_proxy prism_dedicated_server:4010
 }


### PR DESCRIPTION
Caddyfile still pointed to the old container names