### PR TITLE
chore: remove duplicate logs

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -76,8 +76,6 @@ func (p *leasewebProvider) Configure(
 	req provider.ConfigureRequest,
 	resp *provider.ConfigureResponse,
 ) {
-	tflog.Info(ctx, "Configuring Leaseweb client")
-
 	var config leasewebProviderModel
 	diags := req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
@@ -132,8 +130,6 @@ func (p *leasewebProvider) Configure(
 	ctx = tflog.SetField(ctx, "leaseweb_scheme", scheme)
 	ctx = tflog.SetField(ctx, "leaseweb_token", token)
 	ctx = tflog.MaskFieldValuesWithFieldKeys(ctx, "leaseweb_token")
-
-	tflog.Debug(ctx, "Creating Leaseweb client")
 
 	optional := client.Optional{}
 	if host != "" {

--- a/internal/provider/publiccloud/image_resource.go
+++ b/internal/provider/publiccloud/image_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/leaseweb/leaseweb-go-sdk/publicCloud"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/provider/client"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/utils"
@@ -223,8 +222,6 @@ func (i *imageResource) Create(
 		return
 	}
 
-	tflog.Info(ctx, "Create publiccloud image")
-
 	opts := plan.GetCreateImageOpts()
 
 	sdkImage, httpResponse, err := i.client.CreateImage(ctx).
@@ -269,7 +266,6 @@ func (i *imageResource) Read(
 		return
 	}
 
-	tflog.Info(ctx, fmt.Sprintf("Create publiccloud image resource for %q", state.ID.ValueString()))
 	image, resourceErr := adaptImageDetailsToImageResource(ctx, *sdkImage)
 	if resourceErr != nil {
 		response.Diagnostics.AddError(summary, utils.DefaultErrMsg)
@@ -297,7 +293,6 @@ func (i *imageResource) Update(
 		return
 	}
 
-	tflog.Info(ctx, fmt.Sprintf("Update publiccloud image %q", plan.ID.ValueString()))
 	opts := plan.GetUpdateImageOpts()
 
 	sdkImageDetails, httpResponse, err := i.client.UpdateImage(

--- a/internal/provider/publiccloud/images_data_source.go
+++ b/internal/provider/publiccloud/images_data_source.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/leaseweb/leaseweb-go-sdk/publicCloud"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/provider/client"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/utils"
@@ -188,7 +187,6 @@ func (i *imagesDataSource) Read(
 	_ datasource.ReadRequest,
 	response *datasource.ReadResponse,
 ) {
-	tflog.Info(ctx, "Read Public Cloud images")
 	images, httpResponse, err := getAllImages(ctx, i.client)
 
 	if err != nil {

--- a/internal/provider/publiccloud/instance_resource.go
+++ b/internal/provider/publiccloud/instance_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/leaseweb/leaseweb-go-sdk/publicCloud"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/provider/client"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/utils"
@@ -404,8 +403,6 @@ func (i *instanceResource) Create(
 		return
 	}
 
-	tflog.Info(ctx, "Launch Public Cloud instance")
-
 	opts, err := plan.GetLaunchInstanceOpts(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(summary, utils.DefaultErrMsg)
@@ -446,10 +443,6 @@ func (i *instanceResource) Delete(
 		return
 	}
 
-	tflog.Info(ctx, fmt.Sprintf(
-		"Terminate Public Cloud instance %q",
-		state.ID.ValueString(),
-	))
 	httpResponse, err := i.client.TerminateInstance(
 		ctx,
 		state.ID.ValueString(),
@@ -501,10 +494,6 @@ func (i *instanceResource) Read(
 		return
 	}
 
-	tflog.Info(
-		ctx,
-		fmt.Sprintf("Read Public Cloud instance %q", state.ID.ValueString()),
-	)
 	sdkInstance, httpResponse, err := i.client.
 		GetInstance(ctx, state.ID.ValueString()).
 		Execute()
@@ -513,13 +502,6 @@ func (i *instanceResource) Read(
 		return
 	}
 
-	tflog.Info(
-		ctx,
-		fmt.Sprintf(
-			"Create publiccloud instance resource for %q",
-			state.ID.ValueString(),
-		),
-	)
 	instance, sdkErr := adaptInstanceDetailsToInstanceResource(
 		*sdkInstance,
 		ctx,
@@ -553,10 +535,6 @@ func (i *instanceResource) Update(
 		return
 	}
 
-	tflog.Info(
-		ctx,
-		fmt.Sprintf("Update Public Cloud instance %q", plan.ID.ValueString()),
-	)
 	opts, err := plan.GetUpdateInstanceOpts(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(summary, utils.DefaultErrMsg)

--- a/internal/provider/publiccloud/instances_data_source.go
+++ b/internal/provider/publiccloud/instances_data_source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/leaseweb/leaseweb-go-sdk/publicCloud"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/provider/client"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/utils"
@@ -176,7 +175,6 @@ func (d *instancesDataSource) Read(
 	_ datasource.ReadRequest,
 	resp *datasource.ReadResponse,
 ) {
-	tflog.Info(ctx, "Read public cloud instances")
 	instances, httpResponse, err := getAllInstances(ctx, d.client)
 
 	if err != nil {

--- a/internal/provider/publiccloud/load_balancer_listeners_data_source.go
+++ b/internal/provider/publiccloud/load_balancer_listeners_data_source.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/leaseweb/leaseweb-go-sdk/publicCloud"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/provider/client"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/utils"
@@ -141,7 +140,6 @@ func (l *loadBalancerListenersDataSource) Read(
 		config.LoadBalancerID,
 	)
 
-	tflog.Info(ctx, summary)
 	listeners, httpResponse, err := getAllLoadBalancerListeners(config.generateRequest(ctx, l.client))
 
 	if err != nil {

--- a/internal/provider/publiccloud/load_balancer_resource.go
+++ b/internal/provider/publiccloud/load_balancer_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/leaseweb/leaseweb-go-sdk/publicCloud"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/provider/client"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/utils"
@@ -289,8 +288,6 @@ func (l *loadBalancerResource) Create(
 	if response.Diagnostics.HasError() {
 		return
 	}
-
-	tflog.Info(ctx, "Launch Public Cloud load balancer")
 
 	opts, err := plan.GetLaunchLoadBalancerOpts(ctx)
 	if err != nil {

--- a/internal/provider/publiccloud/load_balancers_data_source.go
+++ b/internal/provider/publiccloud/load_balancers_data_source.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/leaseweb/leaseweb-go-sdk/publicCloud"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/provider/client"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/utils"
@@ -176,7 +175,6 @@ func (l *loadBalancersDataSource) Read(
 	_ datasource.ReadRequest,
 	response *datasource.ReadResponse,
 ) {
-	tflog.Info(ctx, "Read Public Cloud load balancers")
 	loadBalancers, httpResponse, err := getAllLoadBalancers(ctx, l.client)
 
 	if err != nil {

--- a/internal/provider/publiccloud/target_groups_data_source.go
+++ b/internal/provider/publiccloud/target_groups_data_source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/leaseweb/leaseweb-go-sdk/publicCloud"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/provider/client"
 	"github.com/leaseweb/terraform-provider-leaseweb/internal/utils"
@@ -232,7 +231,6 @@ func (t *targetGroupsDataSource) Read(
 		return
 	}
 
-	tflog.Info(ctx, summary)
 	targetGroups, httpResponse, err := getTargetGroups(*apiRequest)
 	if err != nil {
 		utils.Error(ctx, &response.Diagnostics, summary, err, httpResponse)


### PR DESCRIPTION
The logs we manually create are duplicates of logs already created by Terraform. To make life easier I've removed them.