### PR TITLE
feat: inject release version into user agent

### DIFF
--- a/internal/provider/client/client.go
+++ b/internal/provider/client/client.go
@@ -6,7 +6,7 @@ import (
 	"github.com/leaseweb/leaseweb-go-sdk/publicCloud"
 )
 
-const userAgent = "leaseweb-terraform"
+const userAgentBase = "leaseweb-terraform"
 
 // The Client handles instantiation of the SDK.
 type Client struct {
@@ -19,7 +19,7 @@ type Optional struct {
 	Scheme *string
 }
 
-func NewClient(token string, optional Optional) Client {
+func NewClient(token string, optional Optional, version string) Client {
 	publicCloudCfg := publicCloud.NewConfiguration()
 	dedicatedServerCfg := dedicatedServer.NewConfiguration()
 
@@ -31,6 +31,8 @@ func NewClient(token string, optional Optional) Client {
 		publicCloudCfg.Scheme = *optional.Scheme
 		dedicatedServerCfg.Scheme = *optional.Scheme
 	}
+
+	userAgent := userAgentBase + "-" + version
 
 	publicCloudCfg.AddDefaultHeader("X-LSW-Auth", token)
 	publicCloudCfg.UserAgent = userAgent

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -143,7 +143,7 @@ func (p *leasewebProvider) Configure(
 		optional.Scheme = &scheme
 	}
 
-	coreClient := client.NewClient(token, optional)
+	coreClient := client.NewClient(token, optional, p.version)
 
 	resp.DataSourceData = coreClient
 	resp.ResourceData = coreClient

--- a/main.go
+++ b/main.go
@@ -11,10 +11,6 @@ import (
 
 var (
 	version = "dev"
-
-	// goreleaser can pass other information to the main package,
-	// such as the specific commit
-	// https://goreleaser.com/cookbooks/using-main.version/
 )
 
 func main() {


### PR DESCRIPTION
The version is injected into [main.go](https://github.com/Leaseweb/terraform-provider-leaseweb/blob/7afd489f5beb9d4b6a5aa5b2d308d10448408b0c/main.go#L13) via [ldflags](https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-version-information-for-go-applications). This is done with [goreleaser](https://github.com/Leaseweb/terraform-provider-leaseweb/blob/7afd489f5beb9d4b6a5aa5b2d308d10448408b0c/.goreleaser.yml#L18).

The user agent gets the following values:

-  `leaseweb-terraform-dev` for dev builds
- `leaseweb-terraform-test` for tests
- `leaseweb-terraform-v0.10.11`, `leaseweb-terraform-v0.10.12` etc. for production builds