### PR TITLE
ci: implement release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4.1.3
+        with:
+          # this assumes that you have created a personal access token
+          # (PAT) and configured it as a GitHub action secret named
+          # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          # this is a built-in strategy in release-please, see "Action Inputs"
+          # for more options
+          release-type: go

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,3 @@
 docs/
 LICENSE.md
+CHANGELOG.md


### PR DESCRIPTION
Implement [release-please](https://github.com/googleapis/release-please-action) for automated deployments. After each merge the CHANGELOG.md is updated an a new release PR is created. Once merged a new release is created.