### PR TITLE
refactor: unify error handling

### DIFF
--- a/internal/provider/dedicatedserver/contract_panels_data_source.go
+++ b/internal/provider/dedicatedserver/contract_panels_data_source.go
@@ -46,14 +46,7 @@ func (c *controlPanelsDataSource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -94,8 +87,7 @@ func (c *controlPanelsDataSource) Read(
 	}
 
 	if err != nil {
-		summary := fmt.Sprintf("Reading data %s", c.name)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 

--- a/internal/provider/dedicatedserver/credential_data_source.go
+++ b/internal/provider/dedicatedserver/credential_data_source.go
@@ -43,14 +43,7 @@ func (c *credentialDataSource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -120,12 +113,7 @@ func (c *credentialDataSource) Read(
 	).Execute()
 
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Reading data %s for dedicated_server_id %q",
-			c.name,
-			serverID,
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 

--- a/internal/provider/dedicatedserver/credential_resource.go
+++ b/internal/provider/dedicatedserver/credential_resource.go
@@ -59,14 +59,7 @@ func (c *credentialResource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -134,13 +127,7 @@ func (c *credentialResource) Create(
 	).CreateServerCredentialOpts(*opts)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Creating resource %s for username %q and dedicated_server_id %q",
-			c.name,
-			plan.Username.ValueString(),
-			plan.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -176,13 +163,7 @@ func (c *credentialResource) Read(
 	)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Reading resource %s for username %q and dedicated_server_id %q",
-			c.name,
-			state.Username.ValueString(),
-			state.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -221,13 +202,7 @@ func (c *credentialResource) Update(
 	).UpdateServerCredentialOpts(*opts)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Updating resource %s for username %q and dedicated_server_id %q",
-			c.name,
-			plan.Username.ValueString(),
-			plan.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -263,12 +238,6 @@ func (c *credentialResource) Delete(
 	)
 	response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Deleting resource %s for username %q and dedicated_server_id %q",
-			c.name,
-			state.Username.ValueString(),
-			state.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 	}
 }

--- a/internal/provider/dedicatedserver/installation_resource.go
+++ b/internal/provider/dedicatedserver/installation_resource.go
@@ -96,14 +96,7 @@ func (i *installationResource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -369,14 +362,8 @@ func (i *installationResource) Create(
 	serverID := plan.DedicatedServerID.ValueString()
 	result, response, err := i.client.InstallOperatingSystem(ctx, serverID).
 		InstallOperatingSystemOpts(*opts).Execute()
-
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Installaing resource %s for dedicated_server_id %q",
-			i.name,
-			serverID,
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 

--- a/internal/provider/dedicatedserver/notification_setting_bandwidth_resource.go
+++ b/internal/provider/dedicatedserver/notification_setting_bandwidth_resource.go
@@ -60,14 +60,7 @@ func (n *notificationSettingBandwidthResource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -139,12 +132,7 @@ func (n *notificationSettingBandwidthResource) Create(
 	).BandwidthNotificationSettingOpts(*opts)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Creating resource %s for dedicated_server_id %q",
-			n.name,
-			plan.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -180,13 +168,7 @@ func (n *notificationSettingBandwidthResource) Read(
 	)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Reading resource %s for id %q and dedicated_server_id %q",
-			n.name,
-			state.Id.ValueString(),
-			state.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -227,13 +209,7 @@ func (n *notificationSettingBandwidthResource) Update(
 	).BandwidthNotificationSettingOpts(*opts)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Updating resource %s for id %q and dedicated_server_id %q",
-			n.name,
-			plan.Id.ValueString(),
-			plan.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -269,12 +245,6 @@ func (n *notificationSettingBandwidthResource) Delete(
 	)
 	response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Deleting resource %s for id %q and dedicated_server_id %q",
-			n.name,
-			state.Id.ValueString(),
-			state.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 	}
 }

--- a/internal/provider/dedicatedserver/notification_setting_datatraffic_resource.go
+++ b/internal/provider/dedicatedserver/notification_setting_datatraffic_resource.go
@@ -60,14 +60,7 @@ func (n *notificationSettingDatatrafficResource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -139,12 +132,7 @@ func (n *notificationSettingDatatrafficResource) Create(
 	).DataTrafficNotificationSettingOpts(*opts)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Creating resource %s for dedicated_server_id %q",
-			n.name,
-			plan.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -180,13 +168,7 @@ func (n *notificationSettingDatatrafficResource) Read(
 	)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Reading resource %s for id %q and dedicated_server_id %q",
-			n.name,
-			state.Id.ValueString(),
-			state.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -227,13 +209,7 @@ func (n *notificationSettingDatatrafficResource) Update(
 	).DataTrafficNotificationSettingOpts(*opts)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Updating resource %s for id %q and dedicated_server_id %q",
-			n.name,
-			plan.Id.ValueString(),
-			plan.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -269,12 +245,6 @@ func (n *notificationSettingDatatrafficResource) Delete(
 	)
 	response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Deleting resource %s for id %q and dedicated_server_id %q",
-			n.name,
-			state.Id.ValueString(),
-			state.DedicatedServerId.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 	}
 }

--- a/internal/provider/dedicatedserver/operating_systems_data_source.go
+++ b/internal/provider/dedicatedserver/operating_systems_data_source.go
@@ -45,14 +45,7 @@ func (o *operatingSystemsDataSource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -82,8 +75,7 @@ func (o *operatingSystemsDataSource) Read(
 	// NOTE: we show only the latest 50 items.
 	result, response, err := request.Limit(50).Execute()
 	if err != nil {
-		summary := fmt.Sprintf("Reading data %s", o.name)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 

--- a/internal/provider/dedicatedserver/server_data_source.go
+++ b/internal/provider/dedicatedserver/server_data_source.go
@@ -66,14 +66,7 @@ func (s *serverDataSource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -99,12 +92,7 @@ func (s *serverDataSource) Read(
 	request := s.client.GetServer(ctx, config.Id.ValueString())
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Reading data %s for id %q",
-			s.name,
-			config.Id.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 

--- a/internal/provider/dedicatedserver/server_resource.go
+++ b/internal/provider/dedicatedserver/server_resource.go
@@ -89,14 +89,7 @@ func (s *serverResource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -217,12 +210,7 @@ func (s *serverResource) Read(
 
 	newState, response, err := s.getServer(ctx, state.ID.ValueString())
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Reading resource %s for id %q",
-			s.name,
-			state.ID.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -243,12 +231,7 @@ func (s *serverResource) ImportState(
 
 	state, response, err := s.getServer(ctx, req.ID)
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Importing resource %s for id %q",
-			s.name,
-			req.ID,
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -280,12 +263,7 @@ func (s *serverResource) Update(
 			state.ID.ValueString(),
 		).UpdateServerReferenceOpts(*opts).Execute()
 		if err != nil {
-			summary := fmt.Sprintf(
-				"Updating resource %s reference for id %q",
-				s.name,
-				plan.ID.ValueString(),
-			)
-			utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+			utils.SdkError(ctx, &resp.Diagnostics, err, response)
 			return
 		}
 		state.Reference = plan.Reference
@@ -297,24 +275,14 @@ func (s *serverResource) Update(
 			request := s.client.PowerServerOn(ctx, state.ID.ValueString())
 			response, err := request.Execute()
 			if err != nil {
-				summary := fmt.Sprintf(
-					"Updating resource %s powering on for id %q",
-					s.name,
-					state.ID.ValueString(),
-				)
-				utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+				utils.SdkError(ctx, &resp.Diagnostics, err, response)
 				return
 			}
 		} else {
 			request := s.client.PowerServerOff(ctx, state.ID.ValueString())
 			response, err := request.Execute()
 			if err != nil {
-				summary := fmt.Sprintf(
-					"Updating resource %s powering off for id %q",
-					s.name,
-					state.ID.ValueString(),
-				)
-				utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+				utils.SdkError(ctx, &resp.Diagnostics, err, response)
 				return
 			}
 		}
@@ -332,12 +300,7 @@ func (s *serverResource) Update(
 			state.PublicIP.ValueString(),
 		).UpdateIpProfileOpts(*opts).Execute()
 		if err != nil {
-			summary := fmt.Sprintf(
-				"Updating resource %s reverse lookup for id %q",
-				s.name,
-				state.ID.ValueString(),
-			)
-			utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+			utils.SdkError(ctx, &resp.Diagnostics, err, response)
 			return
 		}
 		state.ReverseLookup = plan.ReverseLookup
@@ -352,13 +315,7 @@ func (s *serverResource) Update(
 				state.PublicIP.ValueString(),
 			).Execute()
 			if err != nil {
-				summary := fmt.Sprintf(
-					"Updating resource %s null routing an ip for id %q and ip %q",
-					s.name,
-					state.ID.ValueString(),
-					state.PublicIP.ValueString(),
-				)
-				utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+				utils.SdkError(ctx, &resp.Diagnostics, err, response)
 				return
 			}
 		} else {
@@ -368,13 +325,7 @@ func (s *serverResource) Update(
 				state.PublicIP.ValueString(),
 			).Execute()
 			if err != nil {
-				summary := fmt.Sprintf(
-					"Updating resource %s remove null routing an ip for id %q and ip %q",
-					s.name,
-					state.ID.ValueString(),
-					state.PublicIP.ValueString(),
-				)
-				utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+				utils.SdkError(ctx, &resp.Diagnostics, err, response)
 				return
 			}
 		}
@@ -390,12 +341,7 @@ func (s *serverResource) Update(
 				state.ID.ValueString(),
 			).CreateServerDhcpReservationOpts(*opts).Execute()
 			if err != nil {
-				summary := fmt.Sprintf(
-					"Updating resource %s creating a DHCP reservation for id %q",
-					s.name,
-					state.ID.ValueString(),
-				)
-				utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+				utils.SdkError(ctx, &resp.Diagnostics, err, response)
 				return
 			}
 		} else {
@@ -404,12 +350,7 @@ func (s *serverResource) Update(
 				state.ID.ValueString(),
 			).Execute()
 			if err != nil {
-				summary := fmt.Sprintf(
-					"Updating resource %s deleting DHCP reservation for id %q",
-					s.name,
-					state.ID.ValueString(),
-				)
-				utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+				utils.SdkError(ctx, &resp.Diagnostics, err, response)
 				return
 			}
 		}
@@ -425,12 +366,7 @@ func (s *serverResource) Update(
 				dedicatedserver.NETWORKTYPEURL_PUBLIC,
 			).Execute()
 			if err != nil {
-				summary := fmt.Sprintf(
-					"Updating resource %s opening public network interface for id %q",
-					s.name,
-					state.ID.ValueString(),
-				)
-				utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+				utils.SdkError(ctx, &resp.Diagnostics, err, response)
 				return
 			}
 		} else {
@@ -440,12 +376,7 @@ func (s *serverResource) Update(
 				dedicatedserver.NETWORKTYPEURL_PUBLIC,
 			).Execute()
 			if err != nil {
-				summary := fmt.Sprintf(
-					"Updating resource %s closing public network interface for id %q",
-					s.name,
-					state.ID.ValueString(),
-				)
-				utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+				utils.SdkError(ctx, &resp.Diagnostics, err, response)
 				return
 			}
 		}
@@ -456,20 +387,11 @@ func (s *serverResource) Update(
 }
 
 func (s *serverResource) Create(
-	ctx context.Context,
+	_ context.Context,
 	_ resource.CreateRequest,
 	response *resource.CreateResponse,
 ) {
-	utils.Error(
-		ctx,
-		&response.Diagnostics,
-		fmt.Sprintf(
-			"Resource %s can only be imported, not created.",
-			s.name,
-		),
-		nil,
-		nil,
-	)
+	utils.ImportOnlyError(&response.Diagnostics)
 }
 
 func (s *serverResource) Delete(

--- a/internal/provider/dedicatedserver/servers_data_source.go
+++ b/internal/provider/dedicatedserver/servers_data_source.go
@@ -45,14 +45,7 @@ func (s *serversDataSource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -109,8 +102,7 @@ func (s *serversDataSource) Read(
 
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf("Reading data %s", s.name)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 	for _, server := range result.GetServers() {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2700,7 +2700,7 @@ resource "leaseweb_dedicated_server" "test" {
 }
 `,
 					ExpectError: regexp.MustCompile(
-						"Resource dedicated_server can only be imported, not created.",
+						"Resource can only be imported, not created.",
 					),
 				},
 			},
@@ -2796,7 +2796,7 @@ resource "leaseweb_public_cloud_ip" "test" {
 }
 `,
 					ExpectError: regexp.MustCompile(
-						"Resource public_cloud_ip can only be imported, not created.",
+						"Resource can only be imported, not created.",
 					),
 				},
 			},

--- a/internal/provider/publiccloud/credential_data_source.go
+++ b/internal/provider/publiccloud/credential_data_source.go
@@ -48,14 +48,7 @@ func (d *credentialDataSource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -125,12 +118,7 @@ func (d *credentialDataSource) Read(
 	).Execute()
 
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Reading data %s for instance_id %q",
-			d.name,
-			instanceID,
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 

--- a/internal/provider/publiccloud/credential_resource.go
+++ b/internal/provider/publiccloud/credential_resource.go
@@ -60,14 +60,7 @@ func (c *credentialResource) Configure(
 	coreClient, ok := req.ProviderData.(client.Client)
 
 	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				req.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&resp.Diagnostics, req.ProviderData)
 		return
 	}
 
@@ -143,13 +136,7 @@ func (c *credentialResource) Create(
 	).StoreCredentialOpts(*opts)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Creating %s for username: %q and instance_id: %q",
-			c.name,
-			plan.Username.ValueString(),
-			plan.InstanceID.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -185,13 +172,7 @@ func (c *credentialResource) Read(
 	)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Reading %s for username: %q and instance_id: %q",
-			c.name,
-			state.Username.ValueString(),
-			state.InstanceID.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -230,13 +211,7 @@ func (c *credentialResource) Update(
 	).UpdateCredentialOpts(*opts)
 	result, response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Updating %s for username: %q and instance_id: %q",
-			c.name,
-			plan.Username.ValueString(),
-			plan.InstanceID.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 		return
 	}
 
@@ -272,12 +247,6 @@ func (c *credentialResource) Delete(
 	)
 	response, err := request.Execute()
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Deleting %s for username: %q and instance_id: %q",
-			c.name,
-			state.Username.ValueString(),
-			state.InstanceID.ValueString(),
-		)
-		utils.Error(ctx, &resp.Diagnostics, summary, err, response)
+		utils.SdkError(ctx, &resp.Diagnostics, err, response)
 	}
 }

--- a/internal/provider/publiccloud/images_data_source.go
+++ b/internal/provider/publiccloud/images_data_source.go
@@ -191,7 +191,7 @@ func (i *imagesDataSource) Read(
 	images, httpResponse, err := getAllImages(ctx, i.client)
 
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, fmt.Sprintf("Reading data %s", i.name), err, httpResponse)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -211,14 +211,7 @@ func (i *imagesDataSource) Configure(
 
 	coreClient, ok := request.ProviderData.(client.Client)
 	if !ok {
-		response.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf(
-				"Expected provider.Client, got: %T. Please report this issue to the provider developers.",
-				request.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&response.Diagnostics, request.ProviderData)
 		return
 	}
 

--- a/internal/provider/publiccloud/instance_iso_resource.go
+++ b/internal/provider/publiccloud/instance_iso_resource.go
@@ -145,14 +145,7 @@ func (i *instanceISOResource) Create(
 			)
 			return
 		}
-
-		utils.Error(
-			ctx,
-			&response.Diagnostics,
-			fmt.Sprintf("Creating resource %s", i.name),
-			nil,
-			httpResponse,
-		)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -175,17 +168,7 @@ func (i *instanceISOResource) Read(
 		currentState.InstanceID.ValueString(),
 	).Execute()
 	if err != nil {
-		utils.Error(
-			ctx,
-			&response.Diagnostics,
-			fmt.Sprintf(
-				"Reading ISO %s for instance %q",
-				i.name,
-				currentState.InstanceID.ValueString(),
-			),
-			err,
-			httpResponse,
-		)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -247,18 +230,7 @@ func (i *instanceISOResource) Update(
 				)
 				return
 			}
-
-			utils.Error(
-				ctx,
-				&response.Diagnostics,
-				fmt.Sprintf(
-					"Attaching/detaching ISO %s for instance %q",
-					i.name,
-					plan.InstanceID.ValueString(),
-				),
-				err,
-				httpResponse,
-			)
+			utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 			return
 		}
 
@@ -281,17 +253,7 @@ func (i *instanceISOResource) Delete(
 	currentState.DesiredID = basetypes.NewStringPointerValue(nil)
 	state, httpResponse, err := updateISO(currentState, i.client, ctx)
 	if err != nil {
-		utils.Error(
-			ctx,
-			&response.Diagnostics,
-			fmt.Sprintf(
-				"Detaching ISO %s from instance %q",
-				i.name,
-				currentState.InstanceID.ValueString(),
-			),
-			err,
-			httpResponse,
-		)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -309,13 +271,7 @@ func (i *instanceISOResource) Configure(
 
 	coreClient, ok := request.ProviderData.(client.Client)
 	if !ok {
-		response.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				request.ProviderData,
-			),
-		)
+		utils.ConfigError(&response.Diagnostics, request.ProviderData)
 		return
 	}
 

--- a/internal/provider/publiccloud/isos_data_source.go
+++ b/internal/provider/publiccloud/isos_data_source.go
@@ -123,7 +123,7 @@ func (i *isosDataSource) Read(
 ) {
 	ISOs, httpResponse, err := getISOs(ctx, i.client)
 	if err != nil {
-		utils.Error(ctx, &resp.Diagnostics, fmt.Sprintf("Reading data %s", i.name), err, httpResponse)
+		utils.SdkError(ctx, &resp.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -146,13 +146,7 @@ func (i *isosDataSource) Configure(
 
 	coreClient, ok := request.ProviderData.(client.Client)
 	if !ok {
-		response.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf(
-				"Expected provider.Client, got: %T. Please report this issue to the provider developers.",
-				request.ProviderData,
-			),
-		)
+		utils.ConfigError(&response.Diagnostics, request.ProviderData)
 		return
 	}
 

--- a/internal/provider/publiccloud/load_balancer_listeners_data_source.go
+++ b/internal/provider/publiccloud/load_balancer_listeners_data_source.go
@@ -135,23 +135,9 @@ func (l *loadBalancerListenersDataSource) Read(
 		return
 	}
 
-	summary := fmt.Sprintf(
-		"Reading data %s for load_balancer_id %q",
-		l.name,
-		config.LoadBalancerID,
-	)
-
 	listeners, httpResponse, err := getAllLoadBalancerListeners(config.generateRequest(ctx, l.client))
-
 	if err != nil {
-		utils.Error(
-			ctx,
-			&response.Diagnostics,
-			summary,
-			err,
-			httpResponse,
-		)
-
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -172,14 +158,7 @@ func (l *loadBalancerListenersDataSource) Configure(
 
 	coreClient, ok := request.ProviderData.(client.Client)
 	if !ok {
-		response.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf(
-				"Expected provider.Client, got: %T. Please report this issue to the provider developers.",
-				request.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&response.Diagnostics, request.ProviderData)
 		return
 	}
 

--- a/internal/provider/publiccloud/load_balancers_data_source.go
+++ b/internal/provider/publiccloud/load_balancers_data_source.go
@@ -178,8 +178,7 @@ func (l *loadBalancersDataSource) Read(
 ) {
 	loadBalancers, httpResponse, err := getAllLoadBalancers(ctx, l.client)
 	if err != nil {
-		summary := fmt.Sprintf("Reading data %s", l.name)
-		utils.Error(ctx, &response.Diagnostics, summary, err, httpResponse)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -202,14 +201,7 @@ func (l *loadBalancersDataSource) Configure(
 
 	coreClient, ok := request.ProviderData.(client.Client)
 	if !ok {
-		response.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf(
-				"Expected provider.Client, got: %T. Please report this issue to the provider developers.",
-				request.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&response.Diagnostics, request.ProviderData)
 		return
 	}
 

--- a/internal/provider/publiccloud/target_group_resource.go
+++ b/internal/provider/publiccloud/target_group_resource.go
@@ -307,11 +307,9 @@ func (t *targetGroupResource) Create(
 		return
 	}
 
-	summary := fmt.Sprintf("Creating resource %s", t.name)
-
 	opts, err := plan.generateCreateOpts(ctx)
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, nil, nil)
+		utils.GeneralError(&response.Diagnostics, ctx, err)
 		return
 	}
 
@@ -320,7 +318,7 @@ func (t *targetGroupResource) Create(
 		Execute()
 
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, err, httpResponse)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -329,7 +327,7 @@ func (t *targetGroupResource) Create(
 		ctx,
 	)
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, nil, nil)
+		utils.GeneralError(&response.Diagnostics, ctx, err)
 		return
 	}
 
@@ -347,17 +345,11 @@ func (t *targetGroupResource) Read(
 		return
 	}
 
-	summary := fmt.Sprintf(
-		"Reading resource %s for ID %q",
-		t.name,
-		state.ID.ValueString(),
-	)
-
 	sdkTargetGroup, httpResponse, err := t.client.
 		GetTargetGroup(ctx, state.ID.ValueString()).
 		Execute()
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, err, httpResponse)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -366,7 +358,7 @@ func (t *targetGroupResource) Read(
 		ctx,
 	)
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, nil, nil)
+		utils.GeneralError(&response.Diagnostics, ctx, err)
 		return
 	}
 
@@ -384,15 +376,9 @@ func (t *targetGroupResource) Update(
 		return
 	}
 
-	summary := fmt.Sprintf(
-		"Updating resource %s for ID %q",
-		t.name,
-		plan.ID.ValueString(),
-	)
-
 	opts, err := plan.generateUpdateOpts(ctx)
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, nil, nil)
+		utils.GeneralError(&response.Diagnostics, ctx, err)
 		return
 	}
 
@@ -401,7 +387,7 @@ func (t *targetGroupResource) Update(
 		UpdateTargetGroupOpts(*opts).
 		Execute()
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, err, httpResponse)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -410,7 +396,7 @@ func (t *targetGroupResource) Update(
 		ctx,
 	)
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, nil, nil)
+		utils.GeneralError(&response.Diagnostics, ctx, err)
 		return
 	}
 
@@ -434,12 +420,7 @@ func (t *targetGroupResource) Delete(
 	).Execute()
 
 	if err != nil {
-		summary := fmt.Sprintf(
-			"Deleting resource %s for ID %q",
-			t.name,
-			state.ID.ValueString(),
-		)
-		utils.Error(ctx, &response.Diagnostics, summary, err, httpResponse)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 	}
 }
 
@@ -455,14 +436,7 @@ func (t *targetGroupResource) Configure(
 	coreClient, ok := request.ProviderData.(client.Client)
 
 	if !ok {
-		response.Diagnostics.AddError(
-			"Unexpected Resource Configure Type",
-			fmt.Sprintf(
-				"Expected client.Client, got: %T. Please report this issue to the provider developers.",
-				request.ProviderData,
-			),
-		)
-
+		utils.ConfigError(&response.Diagnostics, request.ProviderData)
 		return
 	}
 

--- a/internal/provider/publiccloud/target_groups_data_source.go
+++ b/internal/provider/publiccloud/target_groups_data_source.go
@@ -219,21 +219,15 @@ func (t *targetGroupsDataSource) Read(
 		return
 	}
 
-	summary := fmt.Sprintf(
-		"Reading data %s for id %q",
-		t.name,
-		config.ID,
-	)
-
 	apiRequest, err := config.generateRequest(ctx, t.client)
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, err, nil)
+		utils.GeneralError(&response.Diagnostics, ctx, err)
 		return
 	}
 
 	targetGroups, httpResponse, err := getTargetGroups(*apiRequest)
 	if err != nil {
-		utils.Error(ctx, &response.Diagnostics, summary, err, httpResponse)
+		utils.SdkError(ctx, &response.Diagnostics, err, httpResponse)
 		return
 	}
 
@@ -259,13 +253,7 @@ func (t *targetGroupsDataSource) Configure(
 
 	coreClient, ok := request.ProviderData.(client.Client)
 	if !ok {
-		response.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf(
-				"Expected provider.Client, got: %T. Please report this issue to the provider developers.",
-				request.ProviderData,
-			),
-		)
+		utils.ConfigError(&response.Diagnostics, request.ProviderData)
 		return
 	}
 


### PR DESCRIPTION
According to the [documentation](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics) helpers should be used to generate consistent diagnostics

> Create a helper function in your provider code using the diagnostic creation functions available in the [diag package](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/diag) to generate consistent diagnostics for types of errors/warnings. It is also possible to use [custom diagnostics types](https://developer.hashicorp.com/terraform/plugin/framework/diagnostics#custom-diagnostics-types) to accomplish this same goal.

As Terraform itself already tells us what resource/data source an error applies to the summary we use is redundant

![2024-12-13T11:18:55,665836016+01:00](https://github.com/user-attachments/assets/c8c18eb1-2545-4ed3-a69a-acbf383d7a5a)

This PR adds helpers to facilitate all edge cases terraform currently & unify the error handling.

