### PR TITLE
refactor: handle all errors through diagnostics

### DIFF
--- a/internal/provider/publiccloud/image_resource_test.go
+++ b/internal/provider/publiccloud/image_resource_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/leaseweb/leaseweb-go-sdk/v3/publiccloud"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_adaptImageDetailsToImageResource(t *testing.T) {
@@ -37,6 +37,14 @@ func Test_adaptImageDetailsToImageResource(t *testing.T) {
 		[]string{"CENTRAL"},
 	)
 
+	diags := diag.Diagnostics{}
+
+	got := adaptImageDetailsToImageResource(
+		context.TODO(),
+		sdkImageDetails,
+		&diags,
+	)
+
 	want := imageResourceModel{
 		ID:           basetypes.NewStringValue("imageId"),
 		Name:         basetypes.NewStringValue("name"),
@@ -47,11 +55,7 @@ func Test_adaptImageDetailsToImageResource(t *testing.T) {
 		Flavour:      basetypes.NewStringValue("flavour"),
 		Region:       basetypes.NewStringValue("eu-west-3"),
 	}
-	got, err := adaptImageDetailsToImageResource(
-		context.TODO(),
-		sdkImageDetails,
-	)
 
-	require.NoError(t, err)
+	assert.False(t, diags.HasError())
 	assert.Equal(t, want, *got)
 }

--- a/internal/provider/publiccloud/instance_resource.go
+++ b/internal/provider/publiccloud/instance_resource.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -75,7 +76,8 @@ type instanceResourceModel struct {
 func adaptInstanceDetailsToInstanceResource(
 	instanceDetails publiccloud.InstanceDetails,
 	ctx context.Context,
-) (*instanceResourceModel, error) {
+	diags *diag.Diagnostics,
+) *instanceResourceModel {
 	instance := instanceResourceModel{
 		ID:                  basetypes.NewStringValue(instanceDetails.GetId()),
 		Region:              basetypes.NewStringValue(string(instanceDetails.GetRegion())),
@@ -87,7 +89,7 @@ func adaptInstanceDetailsToInstanceResource(
 		MarketAppID:         basetypes.NewStringPointerValue(instanceDetails.MarketAppId.Get()),
 	}
 
-	image, err := utils.AdaptSdkModelToResourceObject(
+	image := utils.AdaptSdkModelToResourceObject(
 		instanceDetails.Image,
 		map[string]attr.Type{
 			"id":            types.StringType,
@@ -113,13 +115,14 @@ func adaptInstanceDetailsToInstanceResource(
 				StorageTypes: emptyList,
 			}
 		},
+		diags,
 	)
-	if err != nil {
-		return nil, fmt.Errorf("adaptInstanceToInstanceResource: %w", err)
+	if diags.HasError() {
+		return nil
 	}
 	instance.Image = image
 
-	ips, err := utils.AdaptSdkModelsToListValue(
+	ips := utils.AdaptSdkModelsToListValue(
 		instanceDetails.Ips,
 		map[string]attr.Type{
 			"reverse_lookup": types.StringType,
@@ -128,25 +131,27 @@ func adaptInstanceDetailsToInstanceResource(
 		},
 		ctx,
 		adaptIpDetailsToIPResource,
+		diags,
 	)
-	if err != nil {
-		return nil, fmt.Errorf("adaptInstanceToInstanceResource: %w", err)
+	if diags.HasError() {
+		return nil
 	}
 	instance.IPs = ips
 
-	contract, err := utils.AdaptSdkModelToResourceObject(
+	contract := utils.AdaptSdkModelToResourceObject(
 		instanceDetails.Contract,
 		contractResourceModel{}.attributeTypes(),
 		ctx,
 		adaptContractToContractResource,
+		diags,
 	)
-	if err != nil {
-		return nil, fmt.Errorf("adaptInstanceToInstanceResource: %w", err)
+	if diags.HasError() {
+		return nil
 	}
 	instance.Contract = contract
 
 	sdkIso, _ := instanceDetails.GetIsoOk()
-	iso, err := utils.AdaptNullableSdkModelToResourceObject(
+	iso := utils.AdaptNullableSdkModelToResourceObject(
 		sdkIso,
 		map[string]attr.Type{
 			"id":   types.StringType,
@@ -159,13 +164,14 @@ func adaptInstanceDetailsToInstanceResource(
 				Name: basetypes.NewStringValue(iso.GetName()),
 			}
 		},
+		diags,
 	)
-	if err != nil {
-		return nil, fmt.Errorf("adaptInstanceToInstanceResource: %w", err)
+	if diags.HasError() {
+		return nil
 	}
 	instance.ISO = iso
 
-	return &instance, nil
+	return &instance
 }
 
 func NewInstanceResource() resource.Resource {
@@ -236,9 +242,12 @@ func (i *instanceResource) Create(
 		return
 	}
 
-	state, err := adaptInstanceDetailsToInstanceResource(*instanceDetails, ctx)
-	if err != nil {
-		utils.GeneralError(&resp.Diagnostics, ctx, err)
+	state := adaptInstanceDetailsToInstanceResource(
+		*instanceDetails,
+		ctx,
+		&resp.Diagnostics,
+	)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -297,12 +306,12 @@ func (i *instanceResource) Read(
 		return
 	}
 
-	newState, err := adaptInstanceDetailsToInstanceResource(
+	newState := adaptInstanceDetailsToInstanceResource(
 		*instanceDetails,
 		ctx,
+		&resp.Diagnostics,
 	)
-	if err != nil {
-		utils.GeneralError(&resp.Diagnostics, ctx, err)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -355,9 +364,12 @@ func (i *instanceResource) Update(
 		return
 	}
 
-	state, err := adaptInstanceDetailsToInstanceResource(*instanceDetails, ctx)
-	if err != nil {
-		utils.GeneralError(&resp.Diagnostics, ctx, err)
+	state := adaptInstanceDetailsToInstanceResource(
+		*instanceDetails,
+		ctx,
+		&resp.Diagnostics,
+	)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/publiccloud/instance_resource_test.go
+++ b/internal/provider/publiccloud/instance_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/leaseweb/leaseweb-go-sdk/v3/publiccloud"
 	"github.com/stretchr/testify/assert"
@@ -63,9 +64,15 @@ func Test_adaptInstanceDetailsToInstanceResource(t *testing.T) {
 		Iso: *publiccloud.NewNullableIso(&isoSdk),
 	}
 
-	got, err := adaptInstanceDetailsToInstanceResource(instance, context.TODO())
+	diags := diag.Diagnostics{}
 
-	require.NoError(t, err)
+	got := adaptInstanceDetailsToInstanceResource(
+		instance,
+		context.TODO(),
+		&diags,
+	)
+
+	require.False(t, diags.HasError())
 
 	assert.Equal(t, "id", got.ID.ValueString())
 	assert.Equal(t, "region", got.Region.ValueString())

--- a/internal/provider/publiccloud/instances_data_source.go
+++ b/internal/provider/publiccloud/instances_data_source.go
@@ -111,9 +111,8 @@ func (d *instancesDataSource) Read(
 	}
 
 	//Get images once
-	images, httpResponse, err := getAllImages(ctx, d.PubliccloudAPI)
-	if err != nil {
-		utils.SdkError(ctx, &resp.Diagnostics, err, httpResponse)
+	images := getAllImages(ctx, d.PubliccloudAPI, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/publiccloud/load_balancer_listener_resource_test.go
+++ b/internal/provider/publiccloud/load_balancer_listener_resource_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/leaseweb/leaseweb-go-sdk/v3/publiccloud"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_adaptLoadBalancerListenerRuleToLoadBalancerListenerDefaultRuleResource(t *testing.T) {
@@ -31,9 +31,12 @@ func Test_adaptLoadBalancerListenerToLoadBalancerListenerResource(t *testing.T) 
 			Port:     22,
 		}
 
-		got, err := adaptLoadBalancerListenerToLoadBalancerListenerResource(
+		diags := diag.Diagnostics{}
+
+		got := adaptLoadBalancerListenerToLoadBalancerListenerResource(
 			sdkLoadBalancerListener,
 			context.TODO(),
+			&diags,
 		)
 
 		want := loadBalancerListenerResourceModel{
@@ -42,7 +45,7 @@ func Test_adaptLoadBalancerListenerToLoadBalancerListenerResource(t *testing.T) 
 			Port:       basetypes.NewInt32Value(22),
 		}
 
-		require.NoError(t, err)
+		assert.False(t, diags.HasError())
 		assert.Equal(t, want, *got)
 	})
 
@@ -58,9 +61,12 @@ func Test_adaptLoadBalancerListenerToLoadBalancerListenerResource(t *testing.T) 
 			},
 		}
 
-		got, err := adaptLoadBalancerListenerToLoadBalancerListenerResource(
+		diags := diag.Diagnostics{}
+
+		got := adaptLoadBalancerListenerToLoadBalancerListenerResource(
 			sdkLoadBalancerListener,
 			context.TODO(),
+			&diags,
 		)
 
 		want, _ := basetypes.NewObjectValueFrom(
@@ -71,7 +77,7 @@ func Test_adaptLoadBalancerListenerToLoadBalancerListenerResource(t *testing.T) 
 			},
 		)
 
-		require.NoError(t, err)
+		assert.False(t, diags.HasError())
 		assert.Equal(t, want, got.DefaultRule)
 	})
 }

--- a/internal/provider/publiccloud/load_balancer_resource_test.go
+++ b/internal/provider/publiccloud/load_balancer_resource_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/leaseweb/leaseweb-go-sdk/v3/publiccloud"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_adaptLoadBalancerDetailsToLoadBalancerResource(t *testing.T) {
@@ -22,12 +22,15 @@ func Test_adaptLoadBalancerDetailsToLoadBalancerResource(t *testing.T) {
 			},
 		}
 
-		got, err := adaptLoadBalancerDetailsToLoadBalancerResource(
+		diags := diag.Diagnostics{}
+
+		got := adaptLoadBalancerDetailsToLoadBalancerResource(
 			loadBalancerDetails,
 			context.TODO(),
+			&diags,
 		)
 
-		require.NoError(t, err)
+		assert.False(t, diags.HasError())
 		assert.Equal(t, "id", got.ID.ValueString())
 		assert.Equal(t, "region", got.Region.ValueString())
 		assert.Equal(t, "lsw.c3.2xlarge", got.Type.ValueString())
@@ -51,12 +54,15 @@ func Test_adaptLoadBalancerDetailsToLoadBalancerResource(t *testing.T) {
 			},
 		}
 
-		got, err := adaptLoadBalancerDetailsToLoadBalancerResource(
+		diags := diag.Diagnostics{}
+
+		got := adaptLoadBalancerDetailsToLoadBalancerResource(
 			loadBalancerDetails,
 			context.TODO(),
+			&diags,
 		)
 
-		require.NoError(t, err)
+		assert.False(t, diags.HasError())
 		assert.Equal(t, "reference", got.Reference.ValueString())
 	})
 }

--- a/internal/provider/publiccloud/target_group_resource_test.go
+++ b/internal/provider/publiccloud/target_group_resource_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/leaseweb/leaseweb-go-sdk/v3/publiccloud"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_healthCheckResourceModel_generateOpts(t *testing.T) {
@@ -64,9 +64,12 @@ func Test_adaptTargetGroupToTargetGroupResource(t *testing.T) {
 			Region:   publiccloud.REGIONNAME_EU_CENTRAL_1,
 		}
 
-		got, err := adaptTargetGroupToTargetGroupResource(
+		diags := diag.Diagnostics{}
+
+		got := adaptTargetGroupToTargetGroupResource(
 			sdkTargetGroup,
 			context.TODO(),
+			&diags,
 		)
 
 		want := targetGroupResourceModel{
@@ -86,7 +89,7 @@ func Test_adaptTargetGroupToTargetGroupResource(t *testing.T) {
 			),
 		}
 
-		require.NoError(t, err)
+		assert.False(t, diags.HasError())
 		assert.Equal(t, want, *got)
 	})
 
@@ -99,15 +102,18 @@ func Test_adaptTargetGroupToTargetGroupResource(t *testing.T) {
 			),
 		}
 
-		targetGroup, err := adaptTargetGroupToTargetGroupResource(
+		diags := diag.Diagnostics{}
+
+		targetGroup := adaptTargetGroupToTargetGroupResource(
 			sdkTargetGroup,
 			context.TODO(),
+			&diags,
 		)
 
 		got := healthCheckResourceModel{}
 		targetGroup.HealthCheck.As(context.TODO(), &got, basetypes.ObjectAsOptions{})
 
-		require.NoError(t, err)
+		assert.False(t, diags.HasError())
 		assert.Equal(t, "HTTP", got.Protocol.ValueString())
 	})
 }


### PR DESCRIPTION
Because all errors have to be passed to response diagnostics anyway it makes sense to do this directly in all the helper functions so SDK errors are handled properly.