### PR TITLE
fix: look for job failure during installation

### DIFF
--- a/internal/provider/dedicatedserver/installation_resource.go
+++ b/internal/provider/dedicatedserver/installation_resource.go
@@ -452,6 +452,11 @@ func (i *installationResource) waitForJobAndRetrieveUntilFinished(serverID, jobI
 			return job, nil
 		}
 
+		if job.GetStatus() == "FAILED" {
+			// Job has failed, return an error
+			return nil, fmt.Errorf("job %s for server %s has failed or was canceled", jobID, serverID)
+		}
+
 		// Sleep for the backoff interval before retrying
 		time.Sleep(bo.NextBackOff())
 		retryCount++


### PR DESCRIPTION
When applying an installation change, if the underlying job fails, terraform would keep looking for success state. With this change, if a failure is detected, the operation is cancelled.